### PR TITLE
Remove composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "sil-org/yii2-email-log-target",
-  "version": "1.1.1",
   "type": "library",
   "description": "Yii2 log target for sending data to email without trace information",
   "keywords": ["yii2", "email", "log", "json"],


### PR DESCRIPTION
Packagist complains that some tags are ignored. This should fix that

> Some tags were ignored because of a version mismatch in composer.json, [read more](https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/).
[View Last Update Log](https://packagist.org/packages/sil-org/yii2-email-log-target#)